### PR TITLE
Update Krowi_WorldMapButtons-1.4.lua

### DIFF
--- a/Libs/Krowi_WorldMapButtons-1.4/Krowi_WorldMapButtons-1.4.lua
+++ b/Libs/Krowi_WorldMapButtons-1.4/Krowi_WorldMapButtons-1.4.lua
@@ -26,7 +26,7 @@ end
 
 local AddButton;
 local function Fix1_3_1Buttons()
-	local old = LibStub("Krowi_WorldMapButtons-1.3");
+	local old = LibStub("Krowi_WorldMapButtons-1.3",true);
 	if old then
 		local children = { WorldMapFrame:GetChildren() };
 		for i, child in ipairs(children) do


### PR DESCRIPTION
In Fix1_3_1Buttons fail silently if old version lib is not available.