### PR TITLE
Fixes link to the full description (wago.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@
   <img src="https://img.shields.io/badge/WowInterface-Krowi's%20Achievement%20Filter-yellow" />
 </a>
 
-[Click here for full description](Descriptions/Wago.io.md)
+[Click here for full description](Descriptions/Wago.md)


### PR DESCRIPTION
The link to the full description (Description/Wago.md) was not correct because it referenced a non existing file.

This PR ensures that Readme.md links to the correct file so users don't get a 404 when clicking on "Click here for full description"