### PR TITLE
data(retail): mark missing PvP achievements as PvP

### DIFF
--- a/DataAddons/Retail/10_Dragonflight/AchievementData.lua
+++ b/DataAddons/Retail/10_Dragonflight/AchievementData.lua
@@ -955,7 +955,7 @@ KrowiAF.AchievementData["10_02_00"] = {
 	-- {19235}, -- Warden of the Dream [Removed in 11.0.7, replaced by 41177]
 	Ach(19276):IsPvP(), -- Verdant Vogue
 	Ach(19293):Pet(4288), -- Friends In Feathers
-	Ach(19294), -- Tour of Duty: Emerald Dream
+	Ach(19294):IsPvP(), -- Tour of Duty: Emerald Dream
 	Ach(19295):PvP(36), -- Verdant Gladiator's Slitherdrake
 	Ach(19296), -- Dragon Glyphs: Eye of Ysera
 	Ach(19297), -- Dragon Glyphs: Furnace Coil

--- a/DataAddons/Retail/12_Midnight/AchievementData.lua
+++ b/DataAddons/Retail/12_Midnight/AchievementData.lua
@@ -127,10 +127,10 @@ KrowiAF.AchievementData["12_00_00"] = {
 	Ach(61213), -- Heroic: Magisters' Terrace
 	Ach(61214), -- Mythic: Magisters' Terrace
 	Ach(61219), -- No Time to Paws
-	Ach(61221), -- Tour of Duty: Eversong Woods
-	Ach(61222), -- Tour of Duty: Zul'Aman
-	Ach(61223), -- Tour of Duty: Harandar
-	Ach(61224), -- Tour of Duty: Voidstorm
+	Ach(61221):IsPvP(), -- Tour of Duty: Eversong Woods
+	Ach(61222):IsPvP(), -- Tour of Duty: Zul'Aman
+	Ach(61223):IsPvP(), -- Tour of Duty: Harandar
+	Ach(61224):IsPvP(), -- Tour of Duty: Voidstorm
 	Ach(61225):IsPvP(), -- Investigating the Rise
 	Ach(61226):IsPvP(), -- Uprising
 	Ach(61227):IsPvP(), -- Entering the Void
@@ -891,10 +891,10 @@ KrowiAF.AchievementData["12_01_00"] = {
 	Ach(63681), -- Heroic: Nymrissa Wavecaller
 	Ach(63682), -- Mythic: Nymrissa Wavecaller
 	Ach(63683), -- Nymrissa Wavecaller
-	Ach(63695), -- Arena Exercise
-	Ach(63696), -- Arena Exercise
-	Ach(63697), -- Arena Exercise
-	Ach(63698), -- Arena Exercise
-	Ach(63699), -- World Wide Trainer
+	Ach(63695):IsPvP(), -- Arena Exercise
+	Ach(63696):IsPvP(), -- Arena Exercise
+	Ach(63697):IsPvP(), -- Arena Exercise
+	Ach(63698):IsPvP(), -- Arena Exercise
+	Ach(63699):IsPvP(), -- World Wide Trainer
 	Ach(63838), -- Zul'jarra's Forces Champion
 }

--- a/_Packaging/Changelog.md
+++ b/_Packaging/Changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 100.2
+### Fixed
+- Fixed several PvP achievements not being recognized by the PvP filter (Tour of Duty and Training Grounds achievements)
+
 ## 100.1 - 2026-08-30
 ### Added
 - Zul'jarra's Forces Champion added to The Coiled Isle reputation achievements


### PR DESCRIPTION
## What
Mark several Retail PvP achievements with :IsPvP() so they are correctly handled by the PvP achievement filter.

## Why
These achievements were missing the :IsPvP() classification, causing them to remain visible in expansion and zone categories even when PvP achievements were disabled in the filters.

The affected achievements are:

- Tour of Duty: Emerald Dream
- Tour of Duty: Eversong Woods
- Tour of Duty: Zul'Aman
- Tour of Duty: Harandar
- Tour of Duty: Voidstorm
- Arena Exercise (10 wins)
- Arena Exercise (25 wins)
- Arena Exercise (100 wins)
- Arena Exercise (250 wins)
- World Wide Trainer

## Game Client Affected
- [x] Retail (mainline)
- [ ] Classic (Wrath / Cata / Mists)

## How to Verify In-Game
1. Launch Retail with Krowi's Achievement Filter enabled.
2. Disable PvP achievements in the achievement filters.
3. /reload.
4. Open the achievement window and navigate to the affected expansion/zone categories.
5. Verify that the affected Tour of Duty and Training Grounds achievements are no longer displayed.
6. Re-enable PvP achievements and verify that they are displayed again.

## Checklist
- [ ] New Lua files are registered in the appropriate `Files.xml` manifest
- [ ] New SavedVariables are declared in `Krowi_AchievementFilter.toc`
- [ ] New localization strings are added to `Localization/enUS.lua` **above** the `AUTOGENTOKEN` marker
- [x] `_Packaging/Changelog.md` is updated
- [x] Tested in Retail (if applicable)
- [ ] Tested in Classic (if applicable)
